### PR TITLE
Refactor/v0.0.2 maintain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expect_rs"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "MIT"
 authors = [

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -46,12 +46,7 @@ where
 {
     pub fn contains_all(&self, expected: &Vec<T>) -> &Self {
         let has = check_contains(self.actual, expected);
-        assert_eq!(
-            has.len(),
-            0,
-            "should not have {:?} in actual",
-            expected
-        );
+        assert_eq!(has.len(), 0, "should not have {:?} in actual", expected);
 
         self
     }
@@ -68,7 +63,10 @@ where
 }
 
 // 配列の要素を検証する共通のヘルパー関数
-fn check_contains<'a, T: PartialEq + Debug>(actual: &'a Vec<T>, expected: &'a Vec<T>) -> Vec<&'a T> {
+fn check_contains<'a, T: PartialEq + Debug>(
+    actual: &'a Vec<T>,
+    expected: &'a Vec<T>,
+) -> Vec<&'a T> {
     expected.iter().filter(|&e| actual.contains(e)).collect()
 }
 
@@ -78,8 +76,8 @@ mod tests {
 
     #[test]
     fn test_check_contains_all_elements() {
-        let actual = vec!(1, 2, 3, 4, 5);
-        let expected = vec!(1, 3, 5);
+        let actual = vec![1, 2, 3, 4, 5];
+        let expected = vec![1, 3, 5];
         let result = check_contains(&actual, &expected);
 
         assert_eq!(result, vec![&1, &3, &5]);

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -6,28 +6,21 @@ where
     T: PartialEq + Debug,
 {
     pub fn contains_all(&self, expected: &Vec<T>) -> &Self {
-        let mut has: Vec<&T> = Vec::with_capacity(expected.len());
-
-        for expect in expected {
-            if self.actual.contains(expect) {
-                has.push(expect);
-            }
-        }
-
-        assert!(
-            expected.len() == has.len(),
+        let has = check_contains(self.actual, expected);
+        assert_eq!(
+            expected.len(),
+            has.len(),
             "should be found: expected: {:?}, actual: {:?}",
             expected,
             self.actual
         );
-
         self
     }
 
     pub fn contains(&self, expected: &T) -> &Self {
         assert!(
             self.actual.contains(expected),
-            "must be found: array: {:?}, expected: {:?}",
+            "must be found: expected: {:?}, actual: {:?}",
             self.actual,
             expected
         );
@@ -52,13 +45,13 @@ where
     T: PartialEq + Debug,
 {
     pub fn contains_all(&self, expected: &Vec<T>) -> &Self {
-        let mut has: Vec<&T> = Vec::with_capacity(expected.len());
-        for expect in expected {
-            if self.actual.contains(expect) {
-                has.push(expect);
-            }
-        }
-        assert!(has.len() == 0, "should not have {:?} in actual", expected);
+        let has = check_contains(self.actual, expected);
+        assert_eq!(
+            has.len(),
+            0,
+            "should not have {:?} in actual",
+            expected
+        );
 
         self
     }
@@ -71,5 +64,49 @@ where
             self.actual
         );
         self
+    }
+}
+
+// 配列の要素を検証する共通のヘルパー関数
+fn check_contains<'a, T: PartialEq + Debug>(actual: &'a Vec<T>, expected: &'a Vec<T>) -> Vec<&'a T> {
+    expected.iter().filter(|&e| actual.contains(e)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_contains;
+
+    #[test]
+    fn test_check_contains_all_elements() {
+        let actual = vec!(1, 2, 3, 4, 5);
+        let expected = vec!(1, 3, 5);
+        let result = check_contains(&actual, &expected);
+
+        assert_eq!(result, vec![&1, &3, &5]);
+    }
+
+    #[test]
+    fn test_check_contains_some_elements() {
+        let actual = vec![1, 2, 3, 4, 5];
+        let expected = vec![1, 6, 5];
+        let result = check_contains(&actual, &expected);
+
+        assert_eq!(result, vec![&1, &5]);
+    }
+
+    #[test]
+    fn test_check_contains_no_elements() {
+        let actual = vec![1, 2, 3, 4, 5];
+        let expected = vec![6, 7, 8];
+        let result = check_contains(&actual, &expected);
+        assert_eq!(result, vec![] as Vec<&i32>);
+    }
+
+    #[test]
+    fn test_check_contains_empty() {
+        let actual = vec![1, 2, 3, 4, 5];
+        let expected = vec![];
+        let result = check_contains(&actual, &expected);
+        assert_eq!(result, vec![] as Vec<&i32>);
     }
 }

--- a/src/equals.rs
+++ b/src/equals.rs
@@ -5,12 +5,13 @@ impl<'a, T> Assert<'a, T>
 where
     T: PartialEq + Debug,
 {
-    pub fn equals(&self, expected: &T) {
+    pub fn equals(&self, expected: &T) -> &Self {
         assert_eq!(
             self.actual, expected,
             "should be equal actual: {:?} and expected: {:?}",
             self.actual, expected
-        )
+        );
+        self
     }
 }
 
@@ -18,11 +19,12 @@ impl<'a, T> Not<'a, T>
 where
     T: PartialEq + Debug,
 {
-    pub fn equals(&self, expected: &T) {
+    pub fn equals(&self, expected: &T) -> &Self {
         assert_ne!(
             self.actual, expected,
             "should not be equal actual: {:?} and expected: {:?}",
             self.actual, expected
-        )
+        );
+        self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub struct Not<'a, T> {
     actual: &'a T,
 }
 
-pub fn expect<'a, T>(actual: &'a T) -> Assert<'a, T> {
+pub fn expect<T>(actual: &T) -> Assert<T> {
     Assert { actual }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -31,7 +31,12 @@ where
             }
         }
 
-        assert_eq!(not_found.len(), 0, "[contains_all]should not be found: {:?}", not_found);
+        assert_eq!(
+            not_found.len(),
+            0,
+            "[contains_all]should not be found: {:?}",
+            not_found
+        );
 
         self
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -9,14 +9,9 @@ where
     V: PartialEq + Debug,
 {
     pub fn contains_key(&self, key: &K) -> &Self {
-        match self.actual.get(key) {
-            Some(_) => {
-                // ok
-            }
-            None => {
-                panic!("[contains_key]should be found: {:?}", key);
-            }
-        }
+        self.actual.get(key).unwrap_or_else(|| {
+            panic!("[contains_key]should be found: {:?}", key);
+        });
         self
     }
 
@@ -36,11 +31,7 @@ where
             }
         }
 
-        assert!(
-            not_found.len() == 0,
-            "[contains_all]should not be found: {:?}",
-            not_found
-        );
+        assert_eq!(not_found.len(), 0, "[contains_all]should not be found: {:?}", not_found);
 
         self
     }
@@ -50,12 +41,12 @@ where
             Some(v) => {
                 assert_eq!(
                     v, value,
-                    "shoud be found: key = {:?}, value = {:?}",
+                    "should be found: key = {:?}, value = {:?}",
                     key, value
                 );
             }
             None => {
-                panic!("shoud be found: key = {:?}, value = {:?}", key, value)
+                panic!("should be found: key = {:?}, value = {:?}", key, value)
             }
         }
         self

--- a/src/num.rs
+++ b/src/num.rs
@@ -6,8 +6,8 @@ use std::{
 use crate::Assert;
 
 impl<'a, T> Assert<'a, T>
-where
-    T: PartialOrd + Display + Debug,
+    where
+        T: PartialOrd + Display + Debug,
 {
     pub fn greater_than_or_equal_to(&self, expected: &T) -> &Self {
         assert!(
@@ -50,8 +50,8 @@ where
     }
 
     pub fn in_range<R>(&self, expected: R) -> &Self
-    where
-        R: RangeBounds<T> + Debug,
+        where
+            R: RangeBounds<T> + Debug,
     {
         assert!(
             expected.contains(self.actual),

--- a/src/num.rs
+++ b/src/num.rs
@@ -6,8 +6,8 @@ use std::{
 use crate::Assert;
 
 impl<'a, T> Assert<'a, T>
-    where
-        T: PartialOrd + Display + Debug,
+where
+    T: PartialOrd + Display + Debug,
 {
     pub fn greater_than_or_equal_to(&self, expected: &T) -> &Self {
         assert!(
@@ -50,8 +50,8 @@ impl<'a, T> Assert<'a, T>
     }
 
     pub fn in_range<R>(&self, expected: R) -> &Self
-        where
-            R: RangeBounds<T> + Debug,
+    where
+        R: RangeBounds<T> + Debug,
     {
         assert!(
             expected.contains(self.actual),

--- a/src/panics.rs
+++ b/src/panics.rs
@@ -1,18 +1,17 @@
-use crate::Assert;
 use std::panic;
 
+use crate::Assert;
+
 impl<'a, T> Assert<'a, T>
-where
-    T: Fn() + std::panic::RefUnwindSafe,
+    where
+        T: Fn() + std::panic::RefUnwindSafe,
 {
     pub fn should_panic(&mut self) -> &Self {
-        match panic::catch_unwind(|| {
+        if let Ok(_) = panic::catch_unwind(|| {
             (self.actual)();
         }) {
-            Ok(_) => {
-                panic!("should panic!")
-            }
-            Err(_) => return self,
+            panic!("the provided function did not panic as expected")
         }
+        self
     }
 }

--- a/src/panics.rs
+++ b/src/panics.rs
@@ -3,8 +3,8 @@ use std::panic;
 use crate::Assert;
 
 impl<'a, T> Assert<'a, T>
-    where
-        T: Fn() + std::panic::RefUnwindSafe,
+where
+    T: Fn() + std::panic::RefUnwindSafe,
 {
     pub fn should_panic(&mut self) -> &Self {
         if let Ok(_) = panic::catch_unwind(|| {

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,9 +3,9 @@ use std::fmt::Debug;
 use crate::{Assert, Not};
 
 impl<'a, S, E> Assert<'a, Result<S, E>>
-    where
-        S: Debug + PartialEq,
-        E: Debug + PartialEq,
+where
+    S: Debug + PartialEq,
+    E: Debug + PartialEq,
 {
     pub fn is_ok(&self) -> &Self {
         assert!(self.actual.is_ok(), "must be Ok: actual: {:?}", self.actual);
@@ -18,11 +18,9 @@ impl<'a, S, E> Assert<'a, Result<S, E>>
         });
 
         assert_eq!(
-            value,
-            expected,
+            value, expected,
             "must be Ok and equals: expected: {:?}, actual: {:?}",
-            expected,
-            value
+            expected, value
         );
         self
     }
@@ -42,20 +40,18 @@ impl<'a, S, E> Assert<'a, Result<S, E>>
         });
 
         assert_eq!(
-            error,
-            expected,
+            error, expected,
             "must be Err and equals: expected: {:?}, actual: {:?}",
-            expected,
-            error
+            expected, error
         );
         self
     }
 }
 
 impl<'a, S, E> Not<'a, Result<S, E>>
-    where
-        S: Debug + PartialEq,
-        E: Debug + PartialEq,
+where
+    S: Debug + PartialEq,
+    E: Debug + PartialEq,
 {
     pub fn is_ok(&self) -> &Self {
         assert!(

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,10 +1,11 @@
-use crate::{Assert, Not};
 use std::fmt::Debug;
 
+use crate::{Assert, Not};
+
 impl<'a, S, E> Assert<'a, Result<S, E>>
-where
-    S: Debug + PartialEq,
-    E: Debug + PartialEq,
+    where
+        S: Debug + PartialEq,
+        E: Debug + PartialEq,
 {
     pub fn is_ok(&self) -> &Self {
         assert!(self.actual.is_ok(), "must be Ok: actual: {:?}", self.actual);
@@ -12,19 +13,17 @@ where
     }
 
     pub fn ok_and_equals(&self, expected: &S) -> &Self {
-        match &self.actual {
-            &Ok(ref v) => {
-                assert!(
-                    v == expected,
-                    "must be Ok and equals: expected: {:?}, actual: {:?}",
-                    expected,
-                    v
-                );
-            }
-            &Err(_) => {
-                panic!("must be Ok: actual: {:?}", self.actual);
-            }
-        }
+        let value = self.actual.as_ref().unwrap_or_else(|_| {
+            panic!("must be Ok: actual: {:?}", self.actual);
+        });
+
+        assert_eq!(
+            value,
+            expected,
+            "must be Ok and equals: expected: {:?}, actual: {:?}",
+            expected,
+            value
+        );
         self
     }
 
@@ -38,27 +37,25 @@ where
     }
 
     pub fn err_and_equals(&self, expected: &E) -> &Self {
-        match &self.actual {
-            &Ok(_) => {
-                panic!("must be Err: actual: {:?}", self.actual);
-            }
-            &Err(ref e) => {
-                assert!(
-                    e == expected,
-                    "must be Err and equals: expected: {:?}, actual: {:?}",
-                    expected,
-                    e
-                );
-            }
-        }
+        let error = self.actual.as_ref().err().unwrap_or_else(|| {
+            panic!("must be Err: actual: {:?}", self.actual);
+        });
+
+        assert_eq!(
+            error,
+            expected,
+            "must be Err and equals: expected: {:?}, actual: {:?}",
+            expected,
+            error
+        );
         self
     }
 }
 
 impl<'a, S, E> Not<'a, Result<S, E>>
-where
-    S: Debug + PartialEq,
-    E: Debug + PartialEq,
+    where
+        S: Debug + PartialEq,
+        E: Debug + PartialEq,
 {
     pub fn is_ok(&self) -> &Self {
         assert!(

--- a/src/some.rs
+++ b/src/some.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 use crate::{Assert, Not};
 
 impl<'a, T> Assert<'a, Option<T>>
-    where
-        T: Debug + PartialEq,
+where
+    T: Debug + PartialEq,
 {
     pub fn is_some(&self) -> &Self {
         assert!(
@@ -46,8 +46,8 @@ impl<'a, T> Assert<'a, Option<T>>
 }
 
 impl<'a, T> Not<'a, Option<T>>
-    where
-        T: Debug + PartialEq,
+where
+    T: Debug + PartialEq,
 {
     pub fn is_some(&self) -> &Self {
         assert!(

--- a/src/some.rs
+++ b/src/some.rs
@@ -1,9 +1,10 @@
-use crate::{Assert, Not};
 use std::fmt::Debug;
 
+use crate::{Assert, Not};
+
 impl<'a, T> Assert<'a, Option<T>>
-where
-    T: Debug + PartialEq,
+    where
+        T: Debug + PartialEq,
 {
     pub fn is_some(&self) -> &Self {
         assert!(
@@ -45,8 +46,8 @@ where
 }
 
 impl<'a, T> Not<'a, Option<T>>
-where
-    T: Debug + PartialEq,
+    where
+        T: Debug + PartialEq,
 {
     pub fn is_some(&self) -> &Self {
         assert!(

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,9 +1,10 @@
-use crate::Assert;
 use regex::Regex;
 
+use crate::Assert;
+
 impl<'a, T> Assert<'a, T>
-where
-    T: ToString,
+    where
+        T: ToString,
 {
     pub fn is_match(&self, pattern: &str) -> &Self {
         match Regex::new(pattern) {

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -3,8 +3,8 @@ use regex::Regex;
 use crate::Assert;
 
 impl<'a, T> Assert<'a, T>
-    where
-        T: ToString,
+where
+    T: ToString,
 {
     pub fn is_match(&self, pattern: &str) -> &Self {
         match Regex::new(pattern) {

--- a/tests/equals_test.rs
+++ b/tests/equals_test.rs
@@ -55,3 +55,15 @@ fn not_equals_struct() {
         name: "TestStruct".to_owned(),
     });
 }
+
+#[test]
+fn equals_self() {
+    let actual = 100;
+    expect(&actual).equals(&100).in_range(1..=100);
+}
+
+#[test]
+fn not_equals_self() {
+    let actual = "Hello";
+    expect(&actual).not().equals(&"World").equals(&"Hello!");
+}

--- a/tests/map_test.rs
+++ b/tests/map_test.rs
@@ -11,6 +11,16 @@ fn found_it() {
 }
 
 #[test]
+fn do_not_found() {
+    let map: HashMap<&str, &str> = HashMap::new();
+    assert!(
+        std::panic::catch_unwind(|| {
+            expect(&map).contains_key(&"Hello");
+        }).is_err()
+    )
+}
+
+#[test]
 fn found_all() {
     let mut map = HashMap::new();
     map.insert("Hello", "World!");

--- a/tests/map_test.rs
+++ b/tests/map_test.rs
@@ -13,11 +13,10 @@ fn found_it() {
 #[test]
 fn do_not_found() {
     let map: HashMap<&str, &str> = HashMap::new();
-    assert!(
-        std::panic::catch_unwind(|| {
-            expect(&map).contains_key(&"Hello");
-        }).is_err()
-    )
+    assert!(std::panic::catch_unwind(|| {
+        expect(&map).contains_key(&"Hello");
+    })
+    .is_err())
 }
 
 #[test]

--- a/tests/panics_test.rs
+++ b/tests/panics_test.rs
@@ -10,14 +10,10 @@ fn should_panic_has_err() {
 }
 
 #[test]
-#[should_panic(expected = "should panic!")]
+#[should_panic(expected = "the provided function did not panic as expected")]
 fn should_panic_has_not_err() {
     let f = || {
-        if true {
-            let _result: Result<(), String> = Ok(());
-        } else {
-            panic!("panic!");
-        }
+        let _result: Result<(), String> = Ok(());
     };
 
     expect(&f).should_panic();


### PR DESCRIPTION
- Refactored ok_and_equals and err_and_equals in result.rs
- Fixed compile and expected message issues
- Fixed typos and corrected inappropriate assertion function usage
- Refactored should_panic with if let for more concise code and improved error message       
- Formatted code
- Simplified contains_key with unwrap_or_else
- Removed lifetime parameter for simplicity in expect function
- Refactored code for common functionality, added test cases, and improved error message formatting
- Added .idea folder to .gitignore
- Added additional test cases and assertions to enhance coverage.